### PR TITLE
adding in functionality for PenRequestBatch to send in a list of emails.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -229,7 +229,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.4</version>
+          <version>0.8.8</version>
         </plugin>
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/rest/RestUtils.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/rest/RestUtils.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.api.student.profile.email.rest;
 
 import ca.bc.gov.educ.api.student.profile.email.props.ApplicationProperties;
 import ca.bc.gov.educ.api.student.profile.email.struct.CHESEmailEntity;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
@@ -72,7 +73,7 @@ public class RestUtils {
     return chesEmail;
   }
 
-  public CHESEmailEntity getChesEmail(final String fromEmail, final String toEmail, final String body, final String subject) {
+  public CHESEmailEntity getChesEmail(final String fromEmail, final List<String> toEmail, final String body, final String subject) {
     final CHESEmailEntity chesEmail = new CHESEmailEntity();
     chesEmail.setBody(body);
     chesEmail.setBodyType("html");
@@ -82,7 +83,7 @@ public class RestUtils {
     chesEmail.setPriority("normal");
     chesEmail.setSubject(subject);
     chesEmail.setTag("tag");
-    chesEmail.getTo().add(toEmail);
+    chesEmail.getTo().addAll(toEmail);
     return chesEmail;
   }
 
@@ -90,7 +91,7 @@ public class RestUtils {
     this.sendEmail(this.getChesEmail(emailAddress, body, subject));
   }
 
-  public void sendEmail(final String fromEmail, final String toEmail, final String body, final String subject) {
+  public void sendEmail(final String fromEmail, final List<String> toEmail, final String body, final String subject) {
     this.sendEmail(this.getChesEmail(fromEmail, toEmail, body, subject));
   }
 }

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/CHESEmailService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/CHESEmailService.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.api.student.profile.email.service;
 
 import ca.bc.gov.educ.api.student.profile.email.rest.RestUtils;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.gmpump.BaseEmailEntity;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ public class CHESEmailService {
     this.restUtils.sendEmail(baseEmailEntity.getEmailAddress(), body, subject);
   }
 
-  public void sendEmail(final String fromEmail, final String toEmail, final String body, final String subject) {
+  public void sendEmail(final String fromEmail, final List<String> toEmail, final String body, final String subject) {
     this.restUtils.sendEmail(fromEmail, toEmail, body, subject);
   }
 

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/GMPEmailService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/GMPEmailService.java
@@ -5,13 +5,12 @@ import ca.bc.gov.educ.api.student.profile.email.exception.InvalidParameterExcept
 import ca.bc.gov.educ.api.student.profile.email.props.ApplicationProperties;
 import ca.bc.gov.educ.api.student.profile.email.struct.v2.EmailNotificationEntity;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.gmpump.*;
+import java.util.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 import static ca.bc.gov.educ.api.student.profile.email.constants.IdentityType.BASIC;
 import static ca.bc.gov.educ.api.student.profile.email.constants.IdentityType.BCSC;
@@ -41,7 +40,7 @@ public class GMPEmailService {
     log.debug("Sending completed PEN email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(penRequest.getEmailAddress())
+      .toEmail(List.of(penRequest.getEmailAddress()))
       .subject(PERSONAL_EDUCATION_NUMBER_PEN_REQUEST)
       .templateName(demographicsChanged ? "completedRequest.demographicChange.gmp" : "completedRequest.gmp")
       .emailFields(Map.of("firstName", StringUtils.defaultString(penRequest.getFirstName()), LOGIN_URL, loginUrl))
@@ -56,7 +55,7 @@ public class GMPEmailService {
     log.debug("Sending rejected PEN email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(penRequest.getEmailAddress())
+      .toEmail(List.of(penRequest.getEmailAddress()))
       .subject(PERSONAL_EDUCATION_NUMBER_PEN_REQUEST)
       .templateName("rejectedRequest.gmp")
       .emailFields(Map.of("rejectionReason", penRequest.getRejectionReason(), LOGIN_URL, loginUrl))
@@ -70,7 +69,7 @@ public class GMPEmailService {
     log.debug("Sending additional info PEN email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(penRequest.getEmailAddress())
+      .toEmail(List.of(penRequest.getEmailAddress()))
       .subject(PERSONAL_EDUCATION_NUMBER_PEN_REQUEST)
       .templateName("additionalInfoRequested.gmp")
       .emailFields(Map.of(LOGIN_URL, loginUrl))
@@ -84,7 +83,7 @@ public class GMPEmailService {
     log.debug("Sending sendStaleReturnedRequestNotificationEmail info GMP email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(penRequest.getEmailAddress())
+      .toEmail(List.of(penRequest.getEmailAddress()))
       .subject(PERSONAL_EDUCATION_NUMBER_PEN_REQUEST)
       .templateName("notify.stale.return.gmp")
       .emailFields(Map.of(LOGIN_URL, loginUrl))
@@ -103,7 +102,7 @@ public class GMPEmailService {
     log.debug("sending verify email.");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(emailVerificationEntity.getEmailAddress())
+      .toEmail(List.of(emailVerificationEntity.getEmailAddress()))
       .subject(VERIFY_EMAIL_SUBJECT)
       .templateName("verifyEmail.gmp")
       .emailFields(Map.of("identityTypeLabel", emailVerificationEntity.getIdentityTypeLabel(), "verificationUrl", emailVerificationEntity.getVerificationUrl(), "jwtToken", emailVerificationEntity.getJwtToken()))

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/MacroEmailService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/MacroEmailService.java
@@ -3,13 +3,13 @@ package ca.bc.gov.educ.api.student.profile.email.service;
 import ca.bc.gov.educ.api.student.profile.email.props.MacroProperties;
 import ca.bc.gov.educ.api.student.profile.email.struct.v2.EmailNotificationEntity;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.macro.MacroEditNotificationEntity;
+import java.util.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.text.MessageFormat;
-import java.util.Map;
 
 @Service
 @Slf4j
@@ -33,7 +33,7 @@ public class MacroEmailService {
 
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(macroEditNotificationEntity.getFromEmail())
-      .toEmail(macroEditNotificationEntity.getToEmail())
+      .toEmail(List.of(macroEditNotificationEntity.getToEmail()))
       .subject(subject)
       .templateName(newMacro ? "macro.create" : "macro.update")
       .emailFields(Map.of("businessUseTypeName", macroEditNotificationEntity.getBusinessUseTypeName(), "macroCode", macroEditNotificationEntity.getMacroCode(), "macroTypeCode", macroEditNotificationEntity.getMacroTypeCode(), "macroText", macroEditNotificationEntity.getMacroText()))

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/UMPEmailService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/service/UMPEmailService.java
@@ -4,13 +4,12 @@ import ca.bc.gov.educ.api.student.profile.email.exception.InvalidParameterExcept
 import ca.bc.gov.educ.api.student.profile.email.props.ApplicationProperties;
 import ca.bc.gov.educ.api.student.profile.email.struct.v2.EmailNotificationEntity;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.gmpump.*;
+import java.util.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 import static ca.bc.gov.educ.api.student.profile.email.constants.IdentityType.BASIC;
 import static ca.bc.gov.educ.api.student.profile.email.constants.IdentityType.BCSC;
@@ -39,7 +38,7 @@ public class UMPEmailService {
     log.debug("Sending completed UMP email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(email.getEmailAddress())
+      .toEmail(List.of(email.getEmailAddress()))
       .subject(STUDENT_PROFILE_REQUEST)
       .templateName("completedRequest.ump")
       .emailFields(Map.of("firstName", StringUtils.defaultString(email.getFirstName()), LOGIN_URL, loginUrl))
@@ -54,7 +53,7 @@ public class UMPEmailService {
     log.debug("Sending rejected UMP email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(email.getEmailAddress())
+      .toEmail(List.of(email.getEmailAddress()))
       .subject(STUDENT_PROFILE_REQUEST)
       .templateName("rejectedRequest.ump")
       .emailFields(Map.of("rejectionReason", email.getRejectionReason(), LOGIN_URL, loginUrl))
@@ -68,7 +67,7 @@ public class UMPEmailService {
     log.debug("Sending additional info UMP email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(email.getEmailAddress())
+      .toEmail(List.of(email.getEmailAddress()))
       .subject(STUDENT_PROFILE_REQUEST)
       .templateName("additionalInfoRequested.ump")
       .emailFields(Map.of(LOGIN_URL, loginUrl))
@@ -81,7 +80,7 @@ public class UMPEmailService {
     log.debug("Sending sendStaleReturnedRequestNotificationEmail info UMP email");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(emailEntity.getEmailAddress())
+      .toEmail(List.of(emailEntity.getEmailAddress()))
       .subject(STUDENT_PROFILE_REQUEST)
       .templateName("notify.stale.return.ump")
       .emailFields(Map.of(LOGIN_URL, loginUrl))
@@ -100,7 +99,7 @@ public class UMPEmailService {
     log.debug("sending verify email for UMP.");
     final var emailNotificationEntity = EmailNotificationEntity.builder()
       .fromEmail(FROM_EMAIL)
-      .toEmail(emailVerificationEntity.getEmailAddress())
+      .toEmail(List.of(emailVerificationEntity.getEmailAddress()))
       .subject(VERIFY_EMAIL_SUBJECT)
       .templateName("verifyEmail.ump")
       .emailFields(Map.of("identityTypeLabel", emailVerificationEntity.getIdentityTypeLabel(), "verificationUrl", emailVerificationEntity.getVerificationUrl(), "jwtToken", emailVerificationEntity.getJwtToken()))

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/struct/v1/penrequestbatch/BatchNotificationEntity.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/struct/v1/penrequestbatch/BatchNotificationEntity.java
@@ -1,10 +1,11 @@
 package ca.bc.gov.educ.api.student.profile.email.struct.v1.penrequestbatch;
 
+import java.util.*;
 import lombok.Data;
 
 @Data
 public abstract class BatchNotificationEntity {
   String fromEmail;
-  String toEmail;
+  List<String> toEmail;
   String submissionNumber;
 }

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/struct/v2/EmailNotificationEntity.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/struct/v2/EmailNotificationEntity.java
@@ -1,12 +1,12 @@
 package ca.bc.gov.educ.api.student.profile.email.struct.v2;
 
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Map;
 
 @Data
 @Builder
@@ -16,7 +16,7 @@ public class EmailNotificationEntity {
   @NotNull(message = "fromEmail can not be null.")
   private String fromEmail;
   @NotNull(message = "toEmail can not be null.")
-  private String toEmail;
+  private List<String> toEmail;
   @NotNull(message = "subject can not be null.")
   private String subject;
 

--- a/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/validator/EmailValidator.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/student/profile/email/validator/EmailValidator.java
@@ -40,9 +40,12 @@ public class EmailValidator {
     if (!PATTERN.matcher(emailEntity.getFromEmail()).matches()) {
       apiValidationErrors.add(this.createEmailFieldError(emailEntity.getFromEmail(), "fromEmail"));
     }
-    if (!PATTERN.matcher(emailEntity.getToEmail()).matches()) {
-      apiValidationErrors.add(this.createEmailFieldError(emailEntity.getToEmail(), "toEmail"));
+    for (String toEmail : emailEntity.getToEmail()) {
+      if (!PATTERN.matcher(toEmail).matches()) {
+        apiValidationErrors.add(this.createEmailFieldError(toEmail, "toEmail"));
+      }
     }
+
     return apiValidationErrors;
   }
 

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/controller/EmailNotificationControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/controller/EmailNotificationControllerTest.java
@@ -4,6 +4,7 @@ import ca.bc.gov.educ.api.student.profile.email.controller.v2.EmailNotificationC
 import ca.bc.gov.educ.api.student.profile.email.rest.RestUtils;
 import ca.bc.gov.educ.api.student.profile.email.struct.v2.EmailNotificationEntity;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,8 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,7 +98,7 @@ public class EmailNotificationControllerTest {
   EmailNotificationEntity createEmailNotificationEntity(String templateName, Map<String, String> emailFields) {
     return EmailNotificationEntity.builder()
       .fromEmail("test@email.co")
-      .toEmail("test@email.co")
+      .toEmail(List.of("test@email.co"))
       .subject("PEN Registry Message")
       .templateName(templateName)
       .emailFields(emailFields)

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/EmailNotificationServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/EmailNotificationServiceTest.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.api.student.profile.email.service;
 
 import ca.bc.gov.educ.api.student.profile.email.rest.RestUtils;
 import ca.bc.gov.educ.api.student.profile.email.struct.v2.EmailNotificationEntity;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,8 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -224,7 +223,7 @@ public class EmailNotificationServiceTest {
   EmailNotificationEntity createEmailNotificationEntity(String templateName, Map<String, String> emailFields) {
     return EmailNotificationEntity.builder()
       .fromEmail("test@email.co")
-      .toEmail("test@email.co")
+      .toEmail(List.of("test@email.co"))
       .subject("PEN Registry Message")
       .templateName(templateName)
       .emailFields(emailFields)

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/EventHandlerDelegatorServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/EventHandlerDelegatorServiceTest.java
@@ -11,6 +11,7 @@ import ca.bc.gov.educ.api.student.profile.email.struct.v1.macro.*;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.penrequestbatch.*;
 import ca.bc.gov.educ.api.student.profile.email.utils.JsonUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
 import lombok.val;
 import org.junit.After;
 import org.junit.Before;
@@ -23,8 +24,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static ca.bc.gov.educ.api.student.profile.email.constants.EventStatus.MESSAGE_PUBLISHED;
@@ -461,7 +460,7 @@ public class EventHandlerDelegatorServiceTest {
   ArchivePenRequestBatchNotificationEntity createArchivePenRequestBatchNotificationEntity() {
     final var entity = new ArchivePenRequestBatchNotificationEntity();
     entity.setSubmissionNumber("000001");
-    entity.setToEmail("test@email.co");
+    entity.setToEmail(List.of("test@email.co"));
     entity.setFromEmail("test@email.co");
     entity.setMincode("123");
     entity.setSchoolName("Columneetza Secondary");
@@ -472,7 +471,7 @@ public class EventHandlerDelegatorServiceTest {
     final PenRequestBatchSchoolErrorNotificationEntity entity = new PenRequestBatchSchoolErrorNotificationEntity();
     entity.setFromEmail("test@test.ca");
     entity.setSubmissionNumber("test");
-    entity.setToEmail("test@test.ca");
+    entity.setToEmail(List.of("test@test.ca"));
     entity.setDateTime(LocalDateTime.now().toString());
     entity.setFailReason("test");
     entity.setFileName("test");
@@ -494,7 +493,7 @@ public class EventHandlerDelegatorServiceTest {
   EmailNotificationEntity createEmailNotificationEntity(String templateName, Map<String, String> emailFields) {
     return EmailNotificationEntity.builder()
       .fromEmail("test@email.co")
-      .toEmail("test@email.co")
+      .toEmail(List.of("test@email.co"))
       .subject("PEN Registry Message")
       .templateName(templateName)
       .emailFields(emailFields)

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/MacroEmailServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/MacroEmailServiceTest.java
@@ -3,6 +3,7 @@ package ca.bc.gov.educ.api.student.profile.email.service;
 import ca.bc.gov.educ.api.student.profile.email.props.MacroProperties;
 import ca.bc.gov.educ.api.student.profile.email.rest.RestUtils;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.macro.MacroEditNotificationEntity;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,14 +41,14 @@ public class MacroEmailServiceTest {
   public void notifyMacroEdit_givenMacroEditNotificationEntityAndNewMacro_shouldSendCorrectMacroCreateEmail() {
     doNothing().when(this.restUtils).sendEmail(any(), any(), any(), any());
     this.macroEmailService.notifyMacroEdit(this.createMacroNotificationEntity(), true);
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.getMacroCreateBody(), this.getMacroCreateSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.getMacroCreateBody(), this.getMacroCreateSubject());
   }
 
   @Test
   public void notifyMacroEdit_givenMacroEditNotificationEntityAndNotNewMacro_shouldSendCorrectMacroUpdateEmail() {
     doNothing().when(this.restUtils).sendEmail(any(), any(), any(), any());
     this.macroEmailService.notifyMacroEdit(this.createMacroNotificationEntity(), false);
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.getMacroUpdateBody(), this.getMacroUpdateSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.getMacroUpdateBody(), this.getMacroUpdateSubject());
   }
 
   MacroEditNotificationEntity createMacroNotificationEntity() {

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/PenRequestBatchEmailServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/service/PenRequestBatchEmailServiceTest.java
@@ -4,6 +4,7 @@ import ca.bc.gov.educ.api.student.profile.email.props.PenRequestBatchProperties;
 import ca.bc.gov.educ.api.student.profile.email.rest.RestUtils;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.penrequestbatch.ArchivePenRequestBatchNotificationEntity;
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.penrequestbatch.PendingRecords;
+import java.util.*;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class PenRequestBatchEmailServiceTest {
   public void sendArchivePenRequestBatchHasSchoolContactEmail_givenArchivePenRequestBatchEmailEntity_shouldSendCorrectEmail() {
     doNothing().when(this.restUtils).sendEmail(any(), any(), any(), any());
     this.prbEmailService.sendArchivePenRequestBatchHasSchoolContactEmail(this.createArchivePenRequestBatchNotificationEntity());
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.getArchivePenRequestBatchHasSchoolContactBody(), this.getArchivePenRequestBatchHasSchoolContactSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.getArchivePenRequestBatchHasSchoolContactBody(), this.getArchivePenRequestBatchHasSchoolContactSubject());
   }
 
   @Test
@@ -51,7 +52,7 @@ public class PenRequestBatchEmailServiceTest {
     val entity = this.createArchivePenRequestBatchNotificationEntity();
     entity.setPendingRecords(PendingRecords.NONE);
     this.prbEmailService.sendArchivePenRequestBatchHasSchoolContactEmail(entity);
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.getArchivePenRequestBatchHasSchoolContactBody(), this.getArchivePenRequestBatchHasSchoolContactSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.getArchivePenRequestBatchHasSchoolContactBody(), this.getArchivePenRequestBatchHasSchoolContactSubject());
   }
 
   @Test
@@ -60,7 +61,7 @@ public class PenRequestBatchEmailServiceTest {
     val entity = this.createArchivePenRequestBatchNotificationEntity();
     entity.setPendingRecords(PendingRecords.SOME);
     this.prbEmailService.sendArchivePenRequestBatchHasSchoolContactEmail(entity);
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.emailBodyPendingSome(), this.getArchivePenRequestBatchHasSchoolContactSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.emailBodyPendingSome(), this.getArchivePenRequestBatchHasSchoolContactSubject());
   }
 
   @Test
@@ -69,7 +70,7 @@ public class PenRequestBatchEmailServiceTest {
     val entity = this.createArchivePenRequestBatchNotificationEntity();
     entity.setPendingRecords(PendingRecords.ALL);
     this.prbEmailService.sendArchivePenRequestBatchHasSchoolContactEmail(entity);
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.emailBodyPendingAll(), this.getArchivePenRequestBatchHasSchoolContactSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.emailBodyPendingAll(), this.getArchivePenRequestBatchHasSchoolContactSubject());
   }
 
   private String emailBodyPendingAll() {
@@ -81,13 +82,13 @@ public class PenRequestBatchEmailServiceTest {
   public void sendArchivePenRequestBatchHasNoSchoolContactEmail_givenArchivePenRequestBatchEmailEntity_shouldSendCorrectEmail() {
     doNothing().when(this.restUtils).sendEmail(any(), any(), any(), any());
     this.prbEmailService.sendArchivePenRequestBatchHasNoSchoolContactEmail(this.createArchivePenRequestBatchNotificationEntity());
-    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", "test@email.co", this.getArchivePenRequestBatchHasNoSchoolContactBody(), this.getArchivePenRequestBatchHasNoSchoolContactSubject());
+    verify(this.restUtils, atLeastOnce()).sendEmail("test@email.co", List.of("test@email.co"), this.getArchivePenRequestBatchHasNoSchoolContactBody(), this.getArchivePenRequestBatchHasNoSchoolContactSubject());
   }
 
   ArchivePenRequestBatchNotificationEntity createArchivePenRequestBatchNotificationEntity() {
     final var entity = new ArchivePenRequestBatchNotificationEntity();
     entity.setSubmissionNumber("000001");
-    entity.setToEmail("test@email.co");
+    entity.setToEmail(List.of("test@email.co"));
     entity.setFromEmail("test@email.co");
     entity.setMincode("123");
     entity.setSchoolName("Columneetza Secondary");

--- a/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/validator/EmailValidatorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/student/profile/email/validator/EmailValidatorTest.java
@@ -1,13 +1,13 @@
 package ca.bc.gov.educ.api.student.profile.email.validator;
 
 import ca.bc.gov.educ.api.student.profile.email.struct.v1.gmpump.UMPRequestEmailVerificationEntity;
+import ca.bc.gov.educ.api.student.profile.email.struct.v2.*;
+import java.util.*;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import lombok.val;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Map;
 
 @RunWith(JUnitParamsRunner.class)
 public class EmailValidatorTest {
@@ -29,5 +29,14 @@ public class EmailValidatorTest {
     entity.setEmailAddress(email);
     val result = this.validator.validateEmail(entity);
     assert (result.size() == expectedErrorSize);
+  }
+
+  @Test
+  public void testValidateEmail_givenMultipleToEmailsWithIncorrectInformation_shouldReturnErrors() {
+    List<String> toEmail = List.of("username@test.ca", "username@test.ca", "a@b.c", "username@yahoo.com.");
+    final EmailNotificationEntity entity = new EmailNotificationEntity("email@email.com", toEmail, "test subject", "template1", Map.of("test", "test") );
+    val result = this.validator.validateEmail(entity);
+
+    assert (result.size() == 2);
   }
 }


### PR DESCRIPTION
Other services still send a singular string ex. Macro, UMP and GMP. So I've put a patch to just create a list of emails so that these continue to work and we do not have to create a separate entitty specific to PenRequestBatch requests. 